### PR TITLE
Implement role support for users

### DIFF
--- a/src/main/java/com/example/properly/auth/AuthController.java
+++ b/src/main/java/com/example/properly/auth/AuthController.java
@@ -1,0 +1,44 @@
+package com.example.properly.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.properly.auth.Role;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthController(AuthRepository authRepository, PasswordEncoder passwordEncoder) {
+        this.authRepository = authRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@RequestBody Users newUser) {
+        if (newUser.getRole() == null) {
+            newUser.setRole(Role.TENANT);
+        }
+        newUser.setPassword(passwordEncoder.encode(newUser.getPassword()));
+        authRepository.save(newUser);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Users> currentUser(Authentication authentication) {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        Users user = authRepository.findByUsername(authentication.getName());
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        user.setPassword(null);
+        return ResponseEntity.ok(user);
+    }
+}

--- a/src/main/java/com/example/properly/auth/Role.java
+++ b/src/main/java/com/example/properly/auth/Role.java
@@ -1,0 +1,6 @@
+package com.example.properly.auth;
+
+public enum Role {
+    TENANT,
+    LANDLORD
+}

--- a/src/main/java/com/example/properly/auth/SecurityConfig.java
+++ b/src/main/java/com/example/properly/auth/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.example.properly.auth;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cglib.proxy.NoOp;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -10,11 +9,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -24,7 +19,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 public class SecurityConfig {
 
     @Autowired
-    private UserDetailService userDetailService;
+    private UserDetailsService userDetailsService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -34,10 +29,10 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
-                .csrf(customizer -> customizer.disable())
-                .authorizeHttpRequests(request -> request.anyRequest().authenticated())
-
-//                .formLogin(Customizer.withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/signup").permitAll()
+                        .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
@@ -47,9 +42,8 @@ public class SecurityConfig {
     @Bean
     public AuthenticationProvider authenticationProvider(PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider
-                .setPasswordEncoder(passwordEncoder)
-                .setUserDetailsPasswordService(userDetailService);
+        provider.setPasswordEncoder(passwordEncoder);
+        provider.setUserDetailsService(userDetailsService);
         return provider;
     }
 

--- a/src/main/java/com/example/properly/auth/UserPrincipal.java
+++ b/src/main/java/com/example/properly/auth/UserPrincipal.java
@@ -18,7 +18,7 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority("USER"));
+        return Collections.singleton(new SimpleGrantedAuthority(user.getRole().name()));
     }
 
     @Override

--- a/src/main/java/com/example/properly/auth/Users.java
+++ b/src/main/java/com/example/properly/auth/Users.java
@@ -1,20 +1,36 @@
 package com.example.properly.auth;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import com.example.properly.auth.Role;
 
 @Entity
 public class Users {
 
     @Id
-    private int id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
     private String username;
     private String password;
-    public int getId() {
+
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.TENANT;
+
+    public Users() {}
+
+    public Users(String username, String password) {
+        this(username, password, Role.TENANT);
+    }
+
+    public Users(String username, String password, Role role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -32,6 +48,14 @@ public class Users {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
     }
 
 }


### PR DESCRIPTION
## Summary
- add a `Role` enum
- allow specifying a role during signup
- store the role in `Users` and expose getters and setters
- map authorities to user role

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dd90cfb00832cb0c663d6c8252338